### PR TITLE
Added null check for inner layout elements

### DIFF
--- a/Runtime/Types/LayoutWindowType.cs
+++ b/Runtime/Types/LayoutWindowType.cs
@@ -742,7 +742,7 @@ namespace UnityEngine.UI.Windows.WindowTypes {
                             ref var com = ref layoutItem.components[c];
                             var comLock = com;
                             if ((windowLayout != com.windowLayout || windowLayout.HasLayoutElementByTagId(com.tag) == false) && windowLayout.layoutElements.Any(x => {
-                                return x.innerLayout == comLock.windowLayout && x.innerLayout.HasLayoutElementByTagId(comLock.tag);
+                                return x.innerLayout != null && x.innerLayout == comLock.windowLayout && x.innerLayout.HasLayoutElementByTagId(comLock.tag);
                             }) == false) {
 
                                 var list = layoutItem.components.ToList();


### PR DESCRIPTION
Unity 2023.1.16f1

If creates inner layout elements for layouts, it can't be assigned correctly in Window component (has editor errors).

So I've added null check to avoid this