### PR TITLE
Fixes for NonDomain editor & InputSystem

### DIFF
--- a/Runtime/Core/WindowSystem.cs
+++ b/Runtime/Core/WindowSystem.cs
@@ -312,14 +312,14 @@ namespace UnityEngine.UI.Windows {
             }
         }
 
-#if WITHOUT_DOMAIN_RELOAD
+        #if WITHOUT_DOMAIN_RELOAD
         [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
         public static void CleanupInstanceOnRun() {
 
             WindowSystem._instance = null;
 
         }
-#endif
+        #endif
 
         public static T GetWindowSystemModule<T>() where T : WindowSystemModule {
 
@@ -379,9 +379,9 @@ namespace UnityEngine.UI.Windows {
         
         public void Awake() {
 
-#if UNITY_2023_1_OR_NEWER && ENABLE_INPUT_SYSTEM
+            #if ENABLE_INPUT_SYSTEM
             UnityEngine.InputSystem.EnhancedTouch.EnhancedTouchSupport.Enable();
-#endif
+            #endif
 
             this.Run();
 

--- a/Runtime/Core/WindowSystem.cs
+++ b/Runtime/Core/WindowSystem.cs
@@ -312,6 +312,15 @@ namespace UnityEngine.UI.Windows {
             }
         }
 
+#if WITHOUT_DOMAIN_RELOAD
+        [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]
+        public static void CleanupInstanceOnRun() {
+
+            WindowSystem._instance = null;
+
+        }
+#endif
+
         public static T GetWindowSystemModule<T>() where T : WindowSystemModule {
 
             if (WindowSystem.instance.modules != null) {

--- a/Runtime/Core/WindowSystem.cs
+++ b/Runtime/Core/WindowSystem.cs
@@ -370,6 +370,10 @@ namespace UnityEngine.UI.Windows {
         
         public void Awake() {
 
+#if UNITY_2023_1_OR_NEWER && ENABLE_INPUT_SYSTEM
+            UnityEngine.InputSystem.EnhancedTouch.EnhancedTouchSupport.Enable();
+#endif
+
             this.Run();
 
         }


### PR DESCRIPTION
1. InputSystem uses EnhancedTouch, but it requires `EnhancedTouchSupport.Enable();` in Awake, so added it

2. When using Unity Editor with disabled domain reload, WindowSystem fails in next scenario

- Open any Layout or Screen prefab for editing
- Then run the game
- WindowSystem cannot show a screen (because  `static WindowSystem _instance` field was already initialized for editor)

So I added cleanup method, started on `[RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.SubsystemRegistration)]`

It can be enabled by `WITHOUT_DOMAIN_RELOAD` define