### PR TITLE
- fix problem with WaitForCompletion in new verssion Addressables 1.21.19

### DIFF
--- a/Runtime/Modules/WindowSystemResources.cs
+++ b/Runtime/Modules/WindowSystemResources.cs
@@ -598,6 +598,7 @@ namespace UnityEngine.UI.Windows.Modules {
         private IEnumerator LoadAddressable_INTERNAL<TResource, TResult>(LoadParameters loadParameters, object handler, Resource resource, System.Func<TResource, TResult> converter) {
             
             var op = Addressables.LoadAssetAsync<TResource>(resource.GetAddress());
+            yield return null;
             System.Action cancellationTask = () => { if (op.IsValid() == true) Addressables.Release(op); };
             this.LoadBegin(handler, cancellationTask);
             if (loadParameters.async == false) op.WaitForCompletion();


### PR DESCRIPTION
При использовании WSUI с последней версией Addressables 1.21.19 вываливается exeption: "Exception: Reentering the Update method is not allowed.  This can happen when calling WaitForCompletion on an operation while inside of a callback."

На форуме юниты предлагают WaitForCompletion заменить на использование await
Ожидание следующего кадра решает эту проблему